### PR TITLE
Refactorings (refs #3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ filterwarnings = [
     # I know looponfailroots is 'deprecated' but ... i'm tired of seeing it
     "ignore::DeprecationWarning:xdist.plugin"
 ]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 branch = true
@@ -86,4 +87,10 @@ exclude_lines = [
   # Typing-related
   "if TYPE_CHECKING:",
   ": +\\.\\.\\.$",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pytest-asyncio>=0.24.0",
+    "pytest-django>=4.9.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,10 @@ def _settings(settings_module):
     django.setup()
 
     return settings
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _dj_autoclear_mailbox() -> None:
+    # Override the `_dj_autoclear_mailbox` test fixture in `pytest_django`.
+    # This works around https://github.com/pytest-dev/pytest-django/issues/993
+    pass

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,2 +1,3 @@
 INSTALLED_APPS = ["django_svcs"]
 MIDDLEWARE = ["django_svcs.middleware.request_container"]
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import pytest
+from django.http import HttpRequest, HttpResponse
+from django.test import AsyncRequestFactory, RequestFactory
+
+from django_svcs import middleware
+
+
+@pytest.fixture(name="svcs_from")
+def mock_svcs_from():
+    with patch("django_svcs.middleware.svcs_from") as mock:
+        yield mock
+
+
+@pytest.fixture(name="sync_view")
+def _sync_view():
+    def view(request: HttpRequest) -> HttpResponse:
+        return HttpResponse("Sync response")
+
+    return view
+
+
+@pytest.fixture(name="async_view")
+def _async_view():
+    async def view(request: HttpRequest) -> HttpResponse:
+        return HttpResponse("Async response")
+
+    return view
+
+
+@pytest.mark.django_db
+def test_sync_middleware(svcs_from, sync_view):
+    request = RequestFactory().get("/")
+    chain = middleware.request_container(sync_view)
+    response = chain(request)
+
+    assert response.content.decode() == "Sync response"
+    assert svcs_from.called
+    svcs_from.assert_called_with(request)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_async_middleware(svcs_from, async_view):
+    request = AsyncRequestFactory().get("/")
+    chain = middleware.request_container(async_view)
+    response = await chain(request)
+
+    assert response.content.decode() == "Async response"
+    assert svcs_from.called
+    svcs_from.assert_called_with(request)


### PR DESCRIPTION
This applies the two changes we seemed to agree on (using a `Local` for request-less storage, and making the middleware sync+async).